### PR TITLE
Change theme to hargo-hugo in config.toml

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -2,7 +2,7 @@
 baseURL = "https://examplesite.com"
 languageCode = "en"
 title = "Hargo | Hugo Ecommerce Site"
-theme = "hargo"
+theme = "hargo-hugo"
 summaryLength = "20"
 paginate = 10
 disqusShortname = ""


### PR DESCRIPTION
In [the documentation](https://docs.gethugothemes.com/hargo/theme-installation/), a `hargo-hugo` directory gets copied into `themes`. But the example site's configuration searches for the `hargo` theme, which doesn't exist. So you end up with a "module not found" error as seen in #2 until either manually changing the configuration to `hargo-hugo` or renaming the directory to `hargo`.